### PR TITLE
feat: Add endpoints and controller for etiquetas

### DIFF
--- a/app/Http/Controllers/EtiquetaController.php
+++ b/app/Http/Controllers/EtiquetaController.php
@@ -1,0 +1,80 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\Etiqueta;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class EtiquetaController extends Controller
+{
+   
+    /**
+     * Obtener todas las etiquetas.
+     */
+    public function index()
+    {
+        $user = auth()->user();  // Esto asegura que el token sea válido
+
+        $etiquetas = Etiqueta::all();
+        return response()->json($etiquetas, 200);
+    }
+
+    /**
+     * Crear una nueva etiqueta.
+     */
+    public function store(Request $request)
+    {
+        $user = auth()->user();  // Verificación del usuario autenticado
+
+        $validator = Validator::make($request->all(), [
+            'nombre' => 'required|string|max:255',
+            'color_hex' => 'required|string|max:7',  // Validar código HEX
+            'descripcion' => 'nullable|string',
+            'categoria' => 'required|string|max:255',
+            'prioridad' => 'required|in:alta,media,baja',
+            'isActive' => 'boolean'
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+        $etiqueta = Etiqueta::create($request->all());
+
+        return response()->json(['message' => 'Etiqueta creada exitosamente', 'etiqueta' => $etiqueta], 201);
+    }
+
+    /**
+     * Actualizar una etiqueta existente.
+     */
+    public function update(Request $request, $id)
+    {
+        $user = auth()->user();  // Verificación del usuario autenticado
+
+        $etiqueta = Etiqueta::findOrFail($id);
+
+        $validatedData = $request->validate([
+            'nombre' => 'sometimes|required|string|max:255',
+            'color_hex' => 'sometimes|required|string|max:7',
+            'descripcion' => 'nullable|string',
+            'categoria' => 'sometimes|required|string|max:255',
+            'prioridad' => 'sometimes|required|in:alta,media,baja',
+            'isActive' => 'boolean'
+        ]);
+
+        $etiqueta->update($validatedData);
+
+        return response()->json(['message' => 'Etiqueta actualizada exitosamente', 'etiqueta' => $etiqueta], 200);
+    }
+
+    /**
+     * Obtener una etiqueta específica.
+     */
+    public function show($id)
+    {
+        $user = auth()->user();  // Verificación del usuario autenticado
+
+        $etiqueta = Etiqueta::findOrFail($id);
+        return response()->json($etiqueta, 200);
+    }
+}

--- a/app/Models/Etiqueta.php
+++ b/app/Models/Etiqueta.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Etiqueta extends Model
+{
+    use HasFactory;
+
+    protected $table = 'etiquetas';
+
+    /**
+     * Los atributos que son asignables masivamente.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'nombre',
+        'color_hex',
+        'descripcion',
+        'categoria',
+        'prioridad',
+        'isActive',
+    ];
+
+    /**
+     * Los atributos que deben ser casteados a tipos nativos.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'isActive' => 'boolean',
+    ];
+}

--- a/database/migrations/2024_08_31_170633_create_label_table.php
+++ b/database/migrations/2024_08_31_170633_create_label_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    
+        public function up()
+    {
+        Schema::create('etiquetas', function (Blueprint $table) {
+            $table->id();  // id primary key
+            $table->string('nombre');
+            $table->string('color_hex');
+            $table->text('descripcion')->nullable();
+            $table->string('categoria');
+            $table->enum('prioridad', ['alta', 'media', 'baja']);
+            $table->boolean('isActive')->default(true);
+            $table->timestamps();  // created_at, updated_at
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('etiquetas');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,8 +3,17 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\LoginController;
 use App\Http\Controllers\UsuarioController;
+use App\Http\Controllers\EtiquetaController;
 
 Route::post('/login', [LoginController::class, 'login']);  // Ruta para el login
 Route::post('/register', [UsuarioController::class, 'register']);  // Ruta para el registro de usuarios
 Route::get('/usuarios', [UsuarioController::class, 'index']);  // Ruta para listar usuarios
 Route::put('/usuarios/{id}', [UsuarioController::class, 'update']);  // Ruta para actualizar usuario
+
+
+Route::middleware('auth:api')->group(function () {
+    Route::get('/etiquetas', [EtiquetaController::class, 'index']);
+    Route::get('/etiquetas/{id}', [EtiquetaController::class, 'show']);
+    Route::post('/etiquetas', [EtiquetaController::class, 'store']);
+    Route::put('/etiquetas/{id}', [EtiquetaController::class, 'update']);
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,6 @@
 
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
+Route::get('/login', function () {
     return view('welcome');
 });


### PR DESCRIPTION
This commit adds the following changes:
- Added routes for CRUD operations on etiquetas in the `api.php` file
- Created `EtiquetaController` to handle etiqueta-related logic
- Implemented methods in `EtiquetaController` for index, show, store, and update operations on etiquetas

These changes are necessary to provide functionality for managing etiquetas in the application.